### PR TITLE
Updated Dependency Version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following dependency in you `pom.xml` file:
 <dependency>
     <groupId>com.xamarin.testcloud</groupId>
     <artifactId>appium</artifactId>
-    <version>1.0</version>
+    <version>1.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Following the instructions, I was unable to add the Test Cloud Appium Extension to my project unless I set the version to 1.0-SNAPSHOT. Updating the README accordingly.